### PR TITLE
Make accelerometer data spyglass compatible

### DIFF
--- a/src/kind_lab_to_nwb/arc_ecephys_2024/spyglass_utils/add_behavior.py
+++ b/src/kind_lab_to_nwb/arc_ecephys_2024/spyglass_utils/add_behavior.py
@@ -93,9 +93,11 @@ def add_behavioral_signals(
     rate = time_info["sampling_frequency"]
     starting_time = time_info["t_start"]
 
-    behavioral_timeseries = BehavioralTimeSeries(name="behavioral_timeseries")
-    behavioral_timeseries.create_timeseries(
-        name="accelerometer_signal",
+    # Create behavioral events container
+    analog_timeseries = BehavioralEvents(name="analog")
+    analog_timeseries.create_timeseries(
+        name="analog",
+        description="Accelerometer signal",
         unit="volts",
         data=time_series,
         starting_time=starting_time,
@@ -108,4 +110,4 @@ def add_behavioral_signals(
     else:
         behavior_module = nwbfile.create_processing_module(name="behavior", description="behavior module")
 
-    behavior_module.add(behavioral_timeseries)
+    behavior_module.add(analog_timeseries)


### PR DESCRIPTION
The spyglass schema for environmental sensors is SensorData which uses the analog BehavioralEvents data interface fron NWB.

To populate SensorData the spyglass source code needs to be updated
#TODO add link to forked repo