### PR TITLE
Remove session start time extraction and improve trial handling

### DIFF
--- a/src/kind_lab_to_nwb/rat_behavioural_phenotyping_2025/interfaces/boris_events_interface.py
+++ b/src/kind_lab_to_nwb/rat_behavioural_phenotyping_2025/interfaces/boris_events_interface.py
@@ -138,7 +138,7 @@ class BORISBehavioralEventsInterface(BaseDataInterface):
         for video_filepath, fps in self._data["media_info"]["fps"].items():
             return float(fps)  # TODO check if fps is the same for all videos
 
-    def add_to_nwbfile(self, nwbfile, metadata, **conversion_options):
+    def add_to_nwbfile(self, nwbfile, metadata, table_name: str = "BehavioralEvents") -> None:
         event_type_meanings_table = MeaningsTable(
             name="EventTypeMeanings", description="Meanings of behavioral event types"
         )
@@ -150,7 +150,7 @@ class BORISBehavioralEventsInterface(BaseDataInterface):
         )
         # Add behavioral events to nwbfile
         behavioral_events = EventsTable(
-            name="BehavioralEvents",
+            name=table_name,
             description="Behavioral events from BORIS output",
             columns=[event_type_column],
             meanings_tables=[event_type_meanings_table],

--- a/src/kind_lab_to_nwb/rat_behavioural_phenotyping_2025/interfaces/boris_events_interface.py
+++ b/src/kind_lab_to_nwb/rat_behavioural_phenotyping_2025/interfaces/boris_events_interface.py
@@ -51,11 +51,6 @@ class BORISBehavioralEventsInterface(BaseDataInterface):
 
     def get_metadata(self) -> DeepDict:
         metadata = super().get_metadata()
-
-        session_start_time = self._get_session_start_time()
-        if session_start_time is not None:
-            metadata["NWBFile"].update(session_start_time=session_start_time)
-
         return metadata
 
     def get_event_types(self) -> List[Dict]:
@@ -125,20 +120,6 @@ class BORISBehavioralEventsInterface(BaseDataInterface):
             event_durations = [np.nan for event in events if event[2] == event_type]
 
         return event_timestamps, event_durations
-
-    def _get_session_start_time(self) -> datetime:
-        """Get the start time of the session.
-
-        Returns
-        -------
-        datetime
-            Start time of the session
-        """
-        if self._data is None:
-            self._data = self._get_data_from_observation_id()
-        session_start_time = self._data["date"]
-        session_start_time = datetime.strptime(session_start_time, "%Y-%m-%dT%H:%M:%S")
-        return session_start_time
 
     def get_event_frame_index(self, event_type: str) -> List[int]:
         # Extract frame index of the events

--- a/src/kind_lab_to_nwb/rat_behavioural_phenotyping_2025/marble_interaction/convert_session.py
+++ b/src/kind_lab_to_nwb/rat_behavioural_phenotyping_2025/marble_interaction/convert_session.py
@@ -92,6 +92,7 @@ def session_to_nwb(
     metadata["NWBFile"]["session_description"] = metadata["SessionTypes"][session_id]["session_description"]
 
     # Check if session_start_time exists in metadata
+    # TODO only date is extracted from the filename, time is not included
     if "session_start_time" not in metadata["NWBFile"]:
         # Extract date from first video filename
         video_path = Path(video_file_paths[0])

--- a/src/kind_lab_to_nwb/rat_behavioural_phenotyping_2025/object_recognition_memory/convert_session.py
+++ b/src/kind_lab_to_nwb/rat_behavioural_phenotyping_2025/object_recognition_memory/convert_session.py
@@ -107,10 +107,11 @@ def session_to_nwb(
     metadata["NWBFile"]["session_description"] = metadata["SessionTypes"][session_id]["session_description"]
 
     # Check if session_start_time exists in metadata
+    # TODO only date is extracted from the filename, time is not included
     if "session_start_time" not in metadata["NWBFile"]:
-        # Extract date from first video filename
+        # Extract date from video filename
         video_path = Path(video_file_paths[0])
-        date_str = video_path.stem.split("_")[0]  # Get "2022-11-23" from filename
+        date_str = video_path.stem.split(" ")[0]  # Get "2022-11-23" from filename
         try:
             # Convert to datetime
             session_start_time = datetime.strptime(date_str, "%Y-%m-%d")

--- a/src/kind_lab_to_nwb/rat_behavioural_phenotyping_2025/object_recognition_memory/convert_session.py
+++ b/src/kind_lab_to_nwb/rat_behavioural_phenotyping_2025/object_recognition_memory/convert_session.py
@@ -10,7 +10,6 @@ from neuroconv.utils import (
     dict_deep_update,
     load_dict_from_file,
 )
-from neuroconv.tools.nwb_helpers import configure_and_write_nwbfile
 
 from kind_lab_to_nwb.rat_behavioural_phenotyping_2025.object_recognition_memory.nwbconverter import (
     ObjectRecognitionNWBConverter,

--- a/src/kind_lab_to_nwb/rat_behavioural_phenotyping_2025/object_recognition_memory/metadata.yaml
+++ b/src/kind_lab_to_nwb/rat_behavioural_phenotyping_2025/object_recognition_memory/metadata.yaml
@@ -44,6 +44,20 @@ Behavior:
         name: BehavioralCamera
         description: CCTV camera mounted on ceiling above arena for behavioral recording
         manufacturer: Example Manufacturer # Example value - actual manufacturer needed
+    BehavioralVideoTestTrial:
+      description: |
+        Video recording of the rat's behavior during the test trial. Recorded using a CCTV camera mounted on the ceiling above the arenas.
+      device:
+        name: BehavioralCamera
+        description: CCTV camera mounted on ceiling above arena for behavioral recording
+        manufacturer: Example Manufacturer # Example value - actual manufacturer needed
+    BehavioralVideoSampleTrial:
+      description: |
+        Video recording of the rat's behavior during the sample trial. Recorded using a CCTV camera mounted on the ceiling above the arenas.
+      device:
+        name: BehavioralCamera
+        description: CCTV camera mounted on ceiling above arena for behavioral recording
+        manufacturer: Example Manufacturer # Example value - actual manufacturer needed
 
 SessionTypes:
   OR_HabD1:
@@ -58,7 +72,7 @@ SessionTypes:
     session_description: |
       Experimental Day 3. Individual rat placed in arena for 10 min habituation
 
-  OR_STM_test:
+  OR_STM:
     session_description: |
       Experimental Day 5. Short-term memory test. 
       Two identical objects (e.g. ceramic tea lights, glass ornaments, never face or animal related) 
@@ -69,7 +83,7 @@ SessionTypes:
       replaced with a replica object and one novel object (counterbalanced for location and object between rats). 
       The rat was returned to the arena for a 3 min test trial, 5 min after the sample trial.
 
-  OR_LTM_test:
+  OR_LTM:
     session_description: |
       Experimental Day 5. Long-term memory test. 
       Two identical objects (e.g. ceramic tea lights, glass ornaments, never face or animal related) 

--- a/src/kind_lab_to_nwb/rat_behavioural_phenotyping_2025/object_recognition_memory/nwbconverter.py
+++ b/src/kind_lab_to_nwb/rat_behavioural_phenotyping_2025/object_recognition_memory/nwbconverter.py
@@ -12,6 +12,11 @@ class ObjectRecognitionNWBConverter(NWBConverter):
     """Primary conversion class for my extracellular electrophysiology dataset."""
 
     data_interface_classes = dict(
-        ObjectRecognitionBehavior=BORISBehavioralEventsInterface,
         Video=ExternalVideoInterface,
+        SampleVideo=ExternalVideoInterface,
+        TestVideo=ExternalVideoInterface,
+        TestObjectRecognitionBehavior=BORISBehavioralEventsInterface,
+        SampleObjectRecognitionBehavior=BORISBehavioralEventsInterface,
     )
+
+    # TODO align sample and test vidoe to the session start time


### PR DESCRIPTION
1. Eliminate the session start time extraction from the BORIS interface (it was not the session start time but the time the video files were processed) 
2. Update the session start time handling to correctly extract date information. 
3. Refactor video handling to support both test and sample video 
4. Refactor observation ids hanfling to support both test and  sample boris output