### PR TITLE
Fix session IDs for Prey Capture sessions

### DIFF
--- a/src/kind_lab_to_nwb/rat_behavioural_phenotyping_2025/utils/utils.py
+++ b/src/kind_lab_to_nwb/rat_behavioural_phenotyping_2025/utils/utils.py
@@ -73,6 +73,9 @@ def get_session_ids_from_excel(subjects_metadata_file_path: FilePath, task_acron
     # Read the Excel file, specifically the "Task acronyms & structure" sheet
     df = pd.read_excel(subjects_metadata_file_path, sheet_name="Task acronyms & structure")
 
+    # Drop the Notes column if it exists
+    df = df.drop(columns=["Notes"], errors="ignore")
+
     # Find the row corresponding to the given task_acronym
     task_row = df[df.iloc[:, 0] == task_acronym]
 
@@ -84,6 +87,8 @@ def get_session_ids_from_excel(subjects_metadata_file_path: FilePath, task_acron
 
     # Remove trailing whitespace from each session ID
     session_ids = [session_id.rstrip() for session_id in session_ids]
+    # Remove parenthesis from session IDs
+    session_ids = [session_id.replace("(", "").replace(")", "") for session_id in session_ids]
     return session_ids
 
 


### PR DESCRIPTION
Remove parenthesis from session IDs and drop unnecessary Notes column

Before:
`['HabD1', 'HabD2', 'HabD3', 'HabD4', 'HabD5', 'TestD1', 'TestD2', 'TestD3', 'TestD4', '(TestD5)', '(Weeto)', 'note: each test day have 4/5 trials, call them 1.1-1.5 if day1, 2.1-2.5 for day2, weeto trials will be called weeto.number']`
After:
`['HabD1', 'HabD2', 'HabD3', 'HabD4', 'HabD5', 'TestD1', 'TestD2', 'TestD3', 'TestD4', 'TestD5', 'Weeto']`
