### PR TITLE
Extract "cage ID" from the POOLED excel files

### DIFF
--- a/src/kind_lab_to_nwb/rat_behavioural_phenotyping_2025/utils/__init__.py
+++ b/src/kind_lab_to_nwb/rat_behavioural_phenotyping_2025/utils/__init__.py
@@ -5,4 +5,5 @@ from .utils import (
     get_session_ids_from_excel,
     get_subject_metadata_from_task,
     parse_datetime_from_filename,
+    update_subjects_metadata_with_cage_ids,
 )

--- a/src/kind_lab_to_nwb/rat_behavioural_phenotyping_2025/utils/__init__.py
+++ b/src/kind_lab_to_nwb/rat_behavioural_phenotyping_2025/utils/__init__.py
@@ -1,7 +1,8 @@
 from .utils import (
+    convert_ts_to_mp4,
     extract_subject_metadata_from_excel,
+    get_cage_ids_from_excel_files,
     get_session_ids_from_excel,
     get_subject_metadata_from_task,
-    convert_ts_to_mp4,
     parse_datetime_from_filename,
 )


### PR DESCRIPTION
Add utility functions to extract cage IDs from Excel files and to update subject metadata with these cage IDs.

* **`get_cage_ids_from_excel_files`**: Added a function to extract a dictionary mapping `(animal_id, cohort_id)` to cage IDs from pooled data Excel files. This function validates the presence of required columns and handles missing or invalid data gracefully.

* **`update_subjects_metadata_with_cage_ids`**: Added a function to update a list of subject metadata dictionaries by adding the corresponding cage ID from a lookup dictionary. The lookup uses `(animal_id, cohort_id)` as the key.

Note that this implementation relies on the current status where we have an excel file with metadata for each line.
